### PR TITLE
Add SDL library related configurations to config.txt to support more display options

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -9,6 +9,13 @@ output.pwm = False
 use.logging = False
 frame.rate = 30
 
+[sdl.env]
+framebuffer.device = /dev/fb1
+mouse.device = /dev/input/touchscreen
+mouse.driver = TSLIB
+video.driver = dummy
+video.display = :0
+
 [serial.interface]
 device.name = /dev/serial0
 baud.rate = 9600

--- a/configfileparser.py
+++ b/configfileparser.py
@@ -50,6 +50,13 @@ FREQUENCY = "frequency"
 GPIO_PIN_LEFT = "gpio.pin.left"
 GPIO_PIN_RIGHT = "gpio.pin.right"
 
+SDL_ENV_VARS = "sdl.env"
+SDL_FB_DEVICE = "framebuffer.device"
+SDL_MOUSE_DEVICE = "mouse.device"
+SDL_MOUSE_DRIVER = "mouse.driver"
+SDL_VIDEO_DRIVER = "video.driver"
+SDL_VIDEO_DISPLAY = "video.display"
+
 SMOOTH_BUFFER_SIZE = "smooth.buffer.size"
 USE_LOGGING = "use.logging"
 USAGE = "usage"
@@ -162,6 +169,8 @@ class ConfigFileParser(object):
         self.meter_config[PWM_INTERFACE][GPIO_PIN_LEFT] = c.getint(PWM_INTERFACE, GPIO_PIN_LEFT)
         self.meter_config[PWM_INTERFACE][GPIO_PIN_RIGHT] = c.getint(PWM_INTERFACE, GPIO_PIN_RIGHT)
         self.meter_config[PWM_INTERFACE][UPDATE_PERIOD] = c.getfloat(PWM_INTERFACE, UPDATE_PERIOD)
+
+        self.meter_config[SDL_ENV_VARS] = self.get_sdl_environment_section(c, SDL_ENV_VARS)
 
         screen_size = c.get(CURRENT, SCREEN_SIZE)
         self.meter_config[SCREEN_INFO] = {}
@@ -283,3 +292,16 @@ class ConfigFileParser(object):
             d[FGR_FILENAME] = None
         d[INDICATOR_FILENAME] = config_file.get(section, INDICATOR_FILENAME)
 
+    def get_sdl_environment_section(self, config_file, section):
+        """ Parser for SDL library OS environment section
+
+        :param config_file: configuration file
+        :param section: section name
+        """
+        d = {}
+        d[SDL_FB_DEVICE] = config_file.get(section, SDL_FB_DEVICE)
+        d[SDL_MOUSE_DEVICE] = config_file.get(section, SDL_MOUSE_DEVICE)
+        d[SDL_MOUSE_DRIVER] = config_file.get(section, SDL_MOUSE_DRIVER)
+        d[SDL_VIDEO_DRIVER] = config_file.get(section, SDL_VIDEO_DRIVER)
+        d[SDL_VIDEO_DISPLAY] = config_file.get(section, SDL_VIDEO_DISPLAY)
+        return d

--- a/peppymeter.py
+++ b/peppymeter.py
@@ -29,7 +29,8 @@ from i2cinterface import I2CInterface
 from pwminterface import PWMInterface
 from screensavermeter import ScreensaverMeter
 from configfileparser import ConfigFileParser, SCREEN_RECT, SCREEN_INFO, WIDTH, HEIGHT, DEPTH, FRAME_RATE, \
-    OUTPUT_DISPLAY, OUTPUT_SERIAL, OUTPUT_I2C, OUTPUT_PWM, DATA_SOURCE, TYPE, USE_LOGGING, USE_VU_METER
+    OUTPUT_DISPLAY, OUTPUT_SERIAL, OUTPUT_I2C, OUTPUT_PWM, DATA_SOURCE, TYPE, USE_LOGGING, USE_VU_METER, \
+    SDL_ENV_VARS, SDL_FB_DEVICE, SDL_MOUSE_DEVICE, SDL_MOUSE_DRIVER, SDL_VIDEO_DRIVER, SDL_VIDEO_DISPLAY
 
 class Peppymeter(ScreensaverMeter):
     """ Peppy Meter class """
@@ -116,19 +117,22 @@ class Peppymeter(ScreensaverMeter):
         screen_h = self.util.meter_config[SCREEN_INFO][HEIGHT]
         depth = self.util.meter_config[SCREEN_INFO][DEPTH]
         
-        os.environ["SDL_FBDEV"] = "/dev/fb1"
-        os.environ["SDL_MOUSEDEV"] = "/dev/input/touchscreen"
-        os.environ["SDL_MOUSEDRV"] = "TSLIB"
+        os.environ["SDL_FBDEV"] = self.util.meter_config[SDL_ENV_VARS][SDL_FB_DEVICE]
+        os.environ["SDL_MOUSEDEV"] = self.util.meter_config[SDL_ENV_VARS][SDL_MOUSE_DEVICE]
+        os.environ["SDL_MOUSEDRV"] = self.util.meter_config[SDL_ENV_VARS][SDL_MOUSE_DRIVER]
         
         if not self.util.meter_config[OUTPUT_DISPLAY]:
-            os.environ["SDL_VIDEODRIVER"] = "dummy"
-            os.environ["DISPLAY"] = ":0"
+            os.environ["SDL_VIDEODRIVER"] = self.util.meter_config[SDL_ENV_VARS][SDL_VIDEO_DRIVER]
+            os.environ["DISPLAY"] = self.util.meter_config[SDL_ENV_VARS][SDL_VIDEO_DISPLAY]
             pygame.display.init()
             pygame.font.init()
             self.util.PYGAME_SCREEN = pygame.display.set_mode((1,1), pygame.DOUBLEBUF, depth)
             return
         
         if "win" not in sys.platform:
+            if self.util.meter_config[SDL_ENV_VARS][SDL_VIDEO_DRIVER] is not "dummy":
+                os.environ["SDL_VIDEODRIVER"] = self.util.meter_config[SDL_ENV_VARS][SDL_VIDEO_DRIVER]
+                os.environ["DISPLAY"] = self.util.meter_config[SDL_ENV_VARS][SDL_VIDEO_DISPLAY]
             pygame.display.init()
             pygame.mouse.set_visible(False)
         else:            
@@ -218,7 +222,7 @@ class Peppymeter(ScreensaverMeter):
 if __name__ == "__main__":
     """ This is called by stand-alone PeppyMeter """
     pm = Peppymeter(standalone=True)
-    if pm.util.meter_config[DATA_SOURCE][TYPE] != SOURCE_PIPE:      
+    if pm.util.meter_config[DATA_SOURCE][TYPE] != SOURCE_PIPE:
         pm.data_source.start_data_source()
         
     pm.init_display()

--- a/peppymeter.py
+++ b/peppymeter.py
@@ -130,7 +130,7 @@ class Peppymeter(ScreensaverMeter):
             return
         
         if "win" not in sys.platform:
-            if self.util.meter_config[SDL_ENV_VARS][SDL_VIDEO_DRIVER] is not "dummy":
+            if not self.util.meter_config[SDL_ENV_VARS][SDL_VIDEO_DRIVER] == "dummy":
                 os.environ["SDL_VIDEODRIVER"] = self.util.meter_config[SDL_ENV_VARS][SDL_VIDEO_DRIVER]
                 os.environ["DISPLAY"] = self.util.meter_config[SDL_ENV_VARS][SDL_VIDEO_DISPLAY]
             pygame.display.init()


### PR DESCRIPTION
This pull-request makes SDL library related configurations available in `config.txt` to support other displays. The default values maintain the same behaviors.

Attached is the video showing on Raspberry Pi 7" 1024x600 screen using 'large' meters with local changes.

https://user-images.githubusercontent.com/449259/102814768-03967900-4380-11eb-8c02-84d274da44fe.MOV

