### PR TITLE
feat: needle skip-if-unchanged optimization and right-to-left linear direction

### DIFF
--- a/circular.py
+++ b/circular.py
@@ -65,7 +65,7 @@ class CircularAnimator(object):
         :param volume: new volume level
         :param init: True - init stage
 
-        :return: index of the current sprite
+        :return: index of the current sprite, or None if unchanged
         """
         if volume == None:
             volume = 0.0 # nullify
@@ -74,11 +74,11 @@ class CircularAnimator(object):
         if n >= len(self.needles):
             n = len(self.needles) - 1
 
-        previous_rect = self.component.bounding_box.copy()
-            
+        # OPTIMIZATION: Return None when needle position unchanged
         if self.previous_index == int(n) and not init:
-            return (n, previous_rect)
+            return (n, None)
             
+        previous_rect = self.component.bounding_box.copy()
         diff = n - self.previous_index
         sub_steps = range(int(abs(diff)) * self.base.steps_per_degree)
         sign = int(math.copysign(1, diff))

--- a/configfileparser.py
+++ b/configfileparser.py
@@ -151,6 +151,7 @@ DIRECTION_BOTTOM_TOP = "bottom-top"
 DIRECTION_TOP_BOTTOM = "top-bottom"
 DIRECTION_EDGES_CENTER = "edges-center"
 DIRECTION_CENTER_EDGES = "center-edges"
+DIRECTION_RIGHT_LEFT = "right-left"
 
 INDICATOR_TYPE = "indicator.type"
 SINGLE = "single"

--- a/linear.py
+++ b/linear.py
@@ -17,7 +17,7 @@
 
 import pygame
 
-from configfileparser import DIRECTION_LEFT_RIGHT, DIRECTION_BOTTOM_TOP, DIRECTION_TOP_BOTTOM, \
+from configfileparser import DIRECTION_LEFT_RIGHT, DIRECTION_RIGHT_LEFT, DIRECTION_BOTTOM_TOP, DIRECTION_TOP_BOTTOM, \
     DIRECTION_EDGES_CENTER, DIRECTION_CENTER_EDGES, SINGLE
 
 class LinearAnimator(object):
@@ -124,9 +124,15 @@ class LinearAnimator(object):
                     component.content_x = component.origin_x - w
             elif self.direction == DIRECTION_LEFT_RIGHT:
                 component.content_x = component.origin_x + w
+            elif self.direction == DIRECTION_RIGHT_LEFT:
+                component.content_x = component.origin_x - w
         else:
             if self.direction == DIRECTION_LEFT_RIGHT:
                 component.bounding_box.w = w
+            elif self.direction == DIRECTION_RIGHT_LEFT:
+                component.bounding_box.w = w
+                component.bounding_box.x = self.comp_width - w
+                component.content_x = component.origin_x + self.comp_width - w
             elif self.direction == DIRECTION_BOTTOM_TOP:
                 component.bounding_box.h = w
                 component.bounding_box.y = self.comp_height - w

--- a/linear.py
+++ b/linear.py
@@ -88,8 +88,9 @@ class LinearAnimator(object):
         :previous_volume: previous volume value
 		:left: True - left channel, False - right channel
         """
+        # OPTIMIZATION: Return None for area when volume unchanged
         if previous_volume == volume and self.indicator_type != SINGLE:
-            return (previous_rect, previous_volume) 
+            return (previous_rect, previous_volume, None) 
                        
         self.base.draw_bgr_fgr(previous_rect, self.base.bgr)
                           


### PR DESCRIPTION
Two changes, currently in production use by the PeppyMeter Screensaver plugin for Volumio (fork: foonerd/peppy_screensaver).

Needle animation skip-if-unchanged optimization
- CircularAnimator.set_sprite() returns early when needle index has not changed, avoiding redundant bgr clear/redraw cycles.
- LinearAnimator.update_channel() returns early when volume is unchanged (non-single mode), skipping mask recalculation and blit.
- Zero visual difference. Reduces CPU on resource-constrained hardware (Raspberry Pi).

Right-to-left direction for linear meters
- Add DIRECTION_RIGHT_LEFT constant ("right-left") to configfileparser.py.
- Add corresponding branches in LinearAnimator.update_channel() for both bar (mask clipping from right edge) and single (indicator moving leftward) modes.
- Template creators enable via meters.txt: direction = right-left
- Completes the direction set: left-right, right-left, bottom-top, top-bottom, edges-center, center-edges.

No breaking changes. Existing meters.txt files with no direction field default to left-right as before.