### PR TITLE
feat: add configurable meter sensitivity gain in dB

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -61,6 +61,7 @@ volume.constant = 80.0
 volume.min = 0.0
 volume.max = 100.0
 volume.max.in.pipe = 100.0
+volume.gain.db = 0
 step = 6
 mono.algorithm = average
 stereo.algorithm = new

--- a/configfileparser.py
+++ b/configfileparser.py
@@ -83,6 +83,7 @@ VOLUME_CONSTANT = "volume.constant"
 VOLUME_MIN = "volume.min"
 VOLUME_MAX = "volume.max"
 VOLUME_MAX_IN_PIPE = "volume.max.in.pipe"
+VOLUME_GAIN_DB = "volume.gain.db"
 STEP = "step"
 MONO_ALGORITHM = "mono.algorithm"
 STEREO_ALGORITHM = "stereo.algorithm"
@@ -295,6 +296,10 @@ class ConfigFileParser(object):
         d[VOLUME_MIN] = config_file.getfloat(section, VOLUME_MIN)
         d[VOLUME_MAX] = config_file.getfloat(section, VOLUME_MAX)
         d[VOLUME_MAX_IN_PIPE] = config_file.getfloat(section, VOLUME_MAX_IN_PIPE)
+        try:
+            d[VOLUME_GAIN_DB] = config_file.getfloat(section, VOLUME_GAIN_DB)
+        except Exception:
+            d[VOLUME_GAIN_DB] = 0.0
         d[MONO_ALGORITHM] = config_file.get(section, MONO_ALGORITHM)
         d[STEREO_ALGORITHM] = config_file.get(section, STEREO_ALGORITHM)
         d[STEP] = config_file.getint(section, STEP)

--- a/datasource.py
+++ b/datasource.py
@@ -61,6 +61,14 @@ class DataSource(object):
         self.min = self.config[VOLUME_MIN]
         self.max_in_ui = self.config[VOLUME_MAX]
         self.max_in_pipe = self.config[VOLUME_MAX_IN_PIPE]
+        # Volumio meter sensitivity (gain) in dB, applied to pipe levels.
+        # 0 dB = unity. Positive dB lifts deflection for quiet / ReplayGain material.
+        # Defaults to 0.0 when the key is absent (older config.txt).
+        try:
+            self.gain_db = float(self.config.get(VOLUME_GAIN_DB, 0.0))
+        except Exception:
+            self.gain_db = 0.0
+        self.gain_mult = 10.0 ** (self.gain_db / 20.0) if self.gain_db > 0.0 else 1.0
         
         self.v = 0
         self.step = self.config[STEP]
@@ -283,8 +291,8 @@ class DataSource(object):
             if length == 0:
                 return (0, 0, 0)
             
-            new_left = int(self.max_in_ui * ((data[length - 4] + (data[length - 3] << 8)) / self.max_in_pipe))
-            new_right = int(self.max_in_ui * ((data[length - 2] + (data[length - 1] << 8)) / self.max_in_pipe))
+            new_left = int(self.max_in_ui * ((data[length - 4] + (data[length - 3] << 8)) / self.max_in_pipe) * self.gain_mult)
+            new_right = int(self.max_in_ui * ((data[length - 2] + (data[length - 1] << 8)) / self.max_in_pipe) * self.gain_mult)
             new_mono = self.get_mono(new_left, new_right)
             
             left = self.get_channel(self.previous_left, new_left)


### PR DESCRIPTION
## Summary
- add `volume.gain.db` to `[data.source]` with tolerant parser fallback for backward compatibility
- apply gain multiplier at the named-pipe data-source chokepoint so ReplayGain-normalized libraries can drive stronger meter deflection
- keep default behavior unchanged at 0 dB and preserve existing smoothing/meter animation behavior

## Test plan
- [x] Smoke-tested locally with gain set to positive values and reset to 0 dB
- [x] Verified old config compatibility by using tolerant parser default when key is absent
- [x] Confirmed no changes to non-pipe test signal sources